### PR TITLE
Add links to Appleseed data dumps

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,9 +167,39 @@
                         Collaborative members collect data from institutions at all points of contact in the Cook County criminal justice system, including the <strong>Chicago Police Department</strong>, the <strong>Illinois State Police</strong>, the <strong>Office of the State's Attorney</strong>, and the <strong>Cook County Jail</strong>.
                         </p>
                         <p>
-                            So far, collaborative members have collected databases including:
+                            The Chicago Data Collaborative has released the following <strong>public data</strong>:
                         </p>
-
+                        <div class="row">
+                            <div class="col-xs-10 col-sm-8">
+                                <table class="table text-left table-indent">
+                                    <tbody>
+                                        <tr>
+                                            <th class="col-xs-1"><i class="fa fa-fw fa-users"></i></th>
+                                            <td>
+                                                Population snapshots from the <strong>Cook County Jail</strong>
+                                                <br/>
+                                                <a href="https://gitlab.com/ChicagoDataCooperative/sheriff-office#readme">
+                                                    Get the data&nbsp;<i class="fa fa-fw fa-arrow-right"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <th class="col-xs-1"><i class="fa fa-fw fa-university"></i></th>
+                                            <td>
+                                                <strong>Central bond court</strong> disposition audit
+                                                <br/>
+                                                <a href="https://gitlab.com/ChicagoDataCooperative/bond-court-dispositions#readme">
+                                                    Get the data&nbsp;<i class="fa fa-fw fa-arrow-right"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        <p>
+                            Private data sources that are currently restricted to Collaborative members include:
+                        </p>
                         <div class="row">
                             <div class="col-xs-10 col-sm-8">
                                 <table class="table text-left table-indent">

--- a/index.html
+++ b/index.html
@@ -193,6 +193,16 @@
                                                 </a>
                                             </td>
                                         </tr>
+                                        <tr>
+                                            <th class="col-xs-1"><i class="fa fa-fw fa-search"></i></th>
+                                            <td>
+                                                <strong>Bond court observation</strong> data
+                                                <br/>
+                                                <a href="https://gitlab.com/ChicagoDataCooperative/court-observation#readme">
+                                                    Get the data&nbsp;<i class="fa fa-fw fa-arrow-right"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>


### PR DESCRIPTION
We'll pull this in when the links go public.